### PR TITLE
Potential fix for code scanning alert no. 8: Clear-text logging of sensitive information

### DIFF
--- a/server/backend/config.py
+++ b/server/backend/config.py
@@ -134,7 +134,7 @@ class Settings(BaseSettings):
         # Build connection string WITHOUT sslmode in the URL
         # SSL will be configured at engine creation time
         result = f"postgresql+asyncpg://{username}:{password}@{host}:{port}/{db_name}"
-        logging.info(f"Built connection string: {result.replace(password, '********')}")
+        logging.info("Database connection string successfully built.")
         return result
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/osuuj/nokia-city-data-analysis/security/code-scanning/8](https://github.com/osuuj/nokia-city-data-analysis/security/code-scanning/8)

To fix the issue, we should avoid logging the connection string entirely, as it contains sensitive information. Instead, we can log a generic message indicating that the connection string was successfully built without including any sensitive details. This ensures that no sensitive data is exposed in the logs.

**Steps to implement the fix:**
1. Remove the log statement on line 137 that logs the connection string.
2. Replace it with a generic log message indicating success, without including the connection string or any sensitive data.
3. Ensure that no other parts of the code log sensitive information.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
