### PR TITLE
Potential fix for code scanning alert no. 7: Information exposure through an exception

### DIFF
--- a/server/backend/main.py
+++ b/server/backend/main.py
@@ -239,7 +239,7 @@ async def health_check(request: Request) -> Dict[str, str]:
         return {"status": "healthy", "database": "connected"}
     except Exception as e:
         logger.error(f"Health check failed: {e}")
-        return {"status": "unhealthy", "error": str(e)}
+        return {"status": "unhealthy", "reason": "internal server error"}
 
 
 @app.get("/api/debug/swagger")


### PR DESCRIPTION
Potential fix for [https://github.com/osuuj/nokia-city-data-analysis/security/code-scanning/7](https://github.com/osuuj/nokia-city-data-analysis/security/code-scanning/7)

To fix the issue, the code should be modified to ensure that sensitive information from exceptions is not exposed to external users. Instead of including the exception message (`str(e)`) in the response, a generic error message should be returned to the client. The detailed exception information should be logged internally using the `logger.error` method for debugging purposes.

The changes will be applied to the `/api/v1/health` endpoint, specifically lines 240–242. The response will be updated to replace the `"error": str(e)` field with a generic error message, such as `"reason": "internal server error"`. No new dependencies are required for this fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
