### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-server-and-run.yml
+++ b/.github/workflows/build-server-and-run.yml
@@ -1,4 +1,6 @@
 name: Deploy Server to AWS
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/osuuj/nokia-city-data-analysis/security/code-scanning/1](https://github.com/osuuj/nokia-city-data-analysis/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the minimal permissions required. Based on the workflow's operations, the `contents: read` permission is sufficient for most steps, as the workflow primarily interacts with external services (AWS, Docker, ECS) using secrets and does not require write access to the repository.

The `permissions` block will be added at the top of the workflow, immediately after the `name` field, to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
