### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/s3-to-rds-data-loader.yml
+++ b/.github/workflows/s3-to-rds-data-loader.yml
@@ -1,5 +1,8 @@
 name: Load Data to DB
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
 


### PR DESCRIPTION
Potential fix for [https://github.com/osuuj/nokia-city-data-analysis/security/code-scanning/5](https://github.com/osuuj/nokia-city-data-analysis/security/code-scanning/5)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the workflow's operations, the `contents: read` permission is sufficient, as the workflow does not perform any actions requiring write access to the repository.

The `permissions` block should be added at the root level of the workflow file to apply to all jobs. This ensures that the `GITHUB_TOKEN` is restricted to read-only access for repository contents.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
