### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pull-request-validation.yml
+++ b/.github/workflows/pull-request-validation.yml
@@ -1,4 +1,6 @@
 name: Pull Request Validation
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/osuuj/nokia-city-data-analysis/security/code-scanning/3](https://github.com/osuuj/nokia-city-data-analysis/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block at the root level of the workflow file. This block will explicitly limit the permissions of the `GITHUB_TOKEN` to `contents: read`, which is sufficient for the operations performed in this workflow. This ensures that no unnecessary write permissions are granted, adhering to the principle of least privilege.

The changes will be made to the `.github/workflows/pull-request-validation.yml` file. Specifically:
- Add a `permissions` block at the top level of the workflow, immediately after the `name` field.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
