### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-etl-and-run.yml
+++ b/.github/workflows/build-etl-and-run.yml
@@ -3,6 +3,9 @@ name: Run ETL Pipeline
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   etl-pipeline:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/osuuj/nokia-city-data-analysis/security/code-scanning/2](https://github.com/osuuj/nokia-city-data-analysis/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow file. Since the workflow does not appear to require write access to the repository, we can set the permissions to `contents: read` at the root level. This ensures that the `GITHUB_TOKEN` has minimal access while maintaining functionality.

The changes will be made to the `.github/workflows/build-etl-and-run.yml` file by adding the `permissions` key at the top level of the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
